### PR TITLE
Abandon ugly default export

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { join } = require("path");
+
 module.exports = {
   extends: "plugin:@phanect/node+ts",
 
@@ -7,7 +9,7 @@ module.exports = {
     node: true,
   },
   parserOptions: {
-    project: "./tsconfig.json",
+    project: join(__dirname, "./tsconfig.json"),
   },
   plugins: [ "@phanect" ],
 };

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,7 +25,7 @@ jobs:
         node-version:
           - 10.x
           - 12.x
-          - 13.x
+          - 14.x
 
     steps:
       - uses: actions/checkout@v1
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: yarn
       - run: yarn build && yarn run release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cache rule testing utility for Cloudflare
 
 ## Requirements
 
-Node.js 10+
+Node.js 10.x, 12.x, and 14.x
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ returns: `Promise<void>` - a Promise object
 Here's an example using Jest:
 
 ```javascript
-import FlareTest from "flaretest"; // or const FlareTest = require("flaretest").default;
+const { FlareTest } = require("flaretest"); // or import FlareTest from "flaretest";
 
 // Initialize flaretest
 const flaretest = new FlareTest("example.com", {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaretest",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "",
   "keywords": [],
   "author": "Jumpei Ogawa <jumpei.ogawa@spelldata.co.jp>",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Jumpei Ogawa <jumpei.ogawa@spelldata.co.jp>",
   "license": "Apache-2.0",
   "main": "dist/FlareTest.js",
+  "types": "./dist/types/FlareTest.d.ts",
   "scripts": {
     "build": "tsc",
     "dev": "ts-node FlareTest.ts",

--- a/src/FlareTest.ts
+++ b/src/FlareTest.ts
@@ -16,7 +16,7 @@ interface FlareTestConfig   {
   cacheLevel?: string;
 }
 
-export default class FlareTest {
+export class FlareTest {
   private hostname: string;
   private userAgents: object;
 

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,5 +1,10 @@
 "use strict";
 
+const { join } = require("path");
+
 module.exports = {
   extends: "plugin:@phanect/jest",
+  parserOptions: {
+    project: join(__dirname, "./tsconfig.json"),
+  },
 };

--- a/test/FlareTest.test.ts
+++ b/test/FlareTest.test.ts
@@ -1,5 +1,5 @@
 import { Server } from "./testutils";
-import FlareTest from "../src/FlareTest";
+import { FlareTest } from "../src/FlareTest";
 
 const flaretest = new FlareTest("localhost", {
   userAgents: {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "module": "commonjs",
+  "include": [
+    "./*.ts"
+  ],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,
+    "declarationDir": "./dist/types",
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": [


### PR DESCRIPTION
In this release, the ugly default export generated by TypeScript is fixed.

```diff
- const FlareTest = require("flaretest").default;
+ const { FlareTest } = require("flaretest");
```

Also, Node.js 13.x support is removed and added 14.x support.